### PR TITLE
Adding support for a command that shows the username of the person who requested a ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ $unban
 ##### `$banned`
 This command can be used by everyone to see what word if any is currently banned.
 
+#### `$whobanned`
+This command can be used by everyone to see the username of the person who has
+requested to ban the current banned world.
+
 ### Other
 - **Mention**: Mentioning the bot in a message to a server channel will have it reply to you with usage instructions
 

--- a/src/commands/bans/ban.ts
+++ b/src/commands/bans/ban.ts
@@ -20,8 +20,9 @@ const ban: Command = {
             } else {
                 const [word] = args;
                 const cleanedWord = removeMarkdown(word);
+                const banRequester = message.author.username;
                 try {
-                    await banImpl(cleanedWord);
+                    await banImpl(cleanedWord, banRequester);
                     reply = `Banned \`${cleanedWord.toLowerCase()}\``;
                 } catch (e) {
                     reply = e?.message ?? `That word can't be banned`;

--- a/src/commands/bans/whobanned.ts
+++ b/src/commands/bans/whobanned.ts
@@ -1,0 +1,17 @@
+
+import {Command} from "@ubccpsc310/bot-base";
+import {Client, Message} from "discord.js";
+import {getBanRequester as whoBannedImpl, getBannedWord as bannedWordImpl} from "../../controllers/BanController";
+
+const whoBanned: Command = {
+    name: "whobanned",
+    "description": "Shows the username of the person who has banned a word",
+    usage: "whobanned",
+    procedure: async (client: Client, message: Message) => {
+        const bannedWord = await bannedWordImpl();
+        const reply = bannedWord != "" ? `${await whoBannedImpl()} has requested the ban` : `No word banned`;
+        return message.channel.send(reply);
+    },
+};
+
+export default whoBanned;

--- a/src/controllers/BanController.ts
+++ b/src/controllers/BanController.ts
@@ -1,6 +1,6 @@
 import {getDatabaseController} from "@ubccpsc310/bot-base";
 
-type BannedWordEntity = {word: string, id: "banned-word"};
+type BannedWordEntity = {word: string, banRequester: string, id: "banned-word"};
 
 const db = getDatabaseController();
 
@@ -13,14 +13,14 @@ const getBannedWord = async (): Promise<string> => {
     return bannedWordCache;
 };
 
-const ban = async (word: string): Promise<void> => {
+const ban = async (word: string, banRequester: string): Promise<void> => {
     if (/\s/.test(word)) {
         throw new Error("Cannot ban a word with whitespace");
     } else if (/\|\|/.test(word)) {
         throw new Error("Cannot ban a word with spoiler marks (||)");
     }
     const lowerWord = word.toLowerCase();
-    await db.set<BannedWordEntity>("settings", {id: "banned-word", word: lowerWord});
+    await db.set<BannedWordEntity>("settings", {id: "banned-word", word: lowerWord, banRequester: banRequester});
     bannedWordCache = lowerWord;
 };
 

--- a/src/controllers/BanController.ts
+++ b/src/controllers/BanController.ts
@@ -13,6 +13,10 @@ const getBannedWord = async (): Promise<string> => {
     return bannedWordCache;
 };
 
+const getBanRequester = async(): Promise<string> => {
+    return (await db.get<BannedWordEntity>("settings", "banned-word")).banRequester;
+};
+
 const ban = async (word: string, banRequester: string): Promise<void> => {
     if (/\s/.test(word)) {
         throw new Error("Cannot ban a word with whitespace");
@@ -29,4 +33,4 @@ const unban = async (): Promise<void> => {
     bannedWordCache = "";
 };
 
-export {ban, unban, getBannedWord};
+export {ban, unban, getBannedWord, getBanRequester};

--- a/test/controllers/BanController.spec.ts
+++ b/test/controllers/BanController.spec.ts
@@ -1,7 +1,7 @@
 import {Context, Suite} from "mocha";
 import {clearDatabase} from "../harness/Util";
 import {Log} from "@ubccpsc310/bot-base";
-import {ban, getBannedWord, unban} from "../../src/controllers/BanController";
+import {ban, getBannedWord, getBanRequester, unban} from "../../src/controllers/BanController";
 import {expect} from "chai";
 
 describe("BanController", function (this: Suite) {
@@ -80,6 +80,16 @@ describe("BanController", function (this: Suite) {
             expect.fail("Banning an*me should have succeeded");
         }
         expect(await getBannedWord()).to.eql("an*me");
+    });
+
+    it("Should be able to return the ban requester of a banned word", async function (this: Context) {
+        try {
+            await ban("scala", defaultBanRequester);
+        } catch (err) {
+            Log.error(err);
+            expect.fail("Banning 'scala' should have succeeded")
+        }
+        expect(await getBanRequester()).to.eql(defaultBanRequester);
     });
 
     it("Should make banned word lowercase", async function (this: Context) {

--- a/test/controllers/BanController.spec.ts
+++ b/test/controllers/BanController.spec.ts
@@ -5,6 +5,9 @@ import {ban, getBannedWord, unban} from "../../src/controllers/BanController";
 import {expect} from "chai";
 
 describe("BanController", function (this: Suite) {
+    
+    const defaultBanRequester: string = "bob's son";
+
     before(async function (this: Context) {
         await clearDatabase();
         Log.info("Database cleared");
@@ -17,7 +20,7 @@ describe("BanController", function (this: Suite) {
 
     it("Should not ban with whitespace", async function (this: Context) {
         try {
-            await ban("  ");
+            await ban("  ", defaultBanRequester);
             expect.fail("Banning whitespace should have failed");
         } catch (err) {
             expect(err).to.be.instanceOf(Error);
@@ -27,21 +30,21 @@ describe("BanController", function (this: Suite) {
 
     it("Should not ban with spoiler marks", async function (this: Context) {
         try {
-            await ban("hello||world");
+            await ban("hello||world", defaultBanRequester);
             expect.fail("Banning hello||world should have failed");
         } catch (err) {
             expect(err).to.be.instanceOf(Error);
             expect(await getBannedWord()).to.eql("");
         }
         try {
-            await ban("something|||else");
+            await ban("something|||else", defaultBanRequester);
             expect.fail("Banning something|||else should have failed");
         } catch (err) {
             expect(err).to.be.instanceOf(Error);
             expect(await getBannedWord()).to.eql("");
         }
         try {
-            await ban("||spoiler||");
+            await ban("||spoiler||", defaultBanRequester);
             expect.fail("Banning ||spoiler|| should have failed");
         } catch (err) {
             expect(err).to.be.instanceOf(Error);
@@ -51,7 +54,7 @@ describe("BanController", function (this: Suite) {
 
     it("Should ban with single bars", async function (this: Context) {
         try {
-            await ban("|w|a|t|");
+            await ban("|w|a|t|", defaultBanRequester);
         } catch (err) {
             Log.error(err);
             expect.fail("Banning |w|a|t| should have succeeded");
@@ -61,7 +64,7 @@ describe("BanController", function (this: Suite) {
 
     it("Should ban with other formatting", async function (this: Context) {
         try {
-            await ban("**what**_are_`you`'doing'```here```");
+            await ban("**what**_are_`you`'doing'```here```", defaultBanRequester);
         } catch (err) {
             Log.error(err);
             expect.fail("Banning **what**_are_`you`'doing'```here``` should have succeeded");
@@ -71,7 +74,7 @@ describe("BanController", function (this: Suite) {
 
     it("Should ban a word", async function (this: Context) {
         try {
-            await ban("an*me");
+            await ban("an*me", defaultBanRequester);
         } catch (err) {
             Log.error(err);
             expect.fail("Banning an*me should have succeeded");
@@ -81,7 +84,7 @@ describe("BanController", function (this: Suite) {
 
     it("Should make banned word lowercase", async function (this: Context) {
         try {
-            await ban("MUT*TION");
+            await ban("MUT*TION", defaultBanRequester);
         } catch (err) {
             Log.error(err);
             expect.fail("Banning MUT*TION should have succeeded");


### PR DESCRIPTION
This PR contains code that implements a new command: `whobanned`.

Any person in the Discord should be able to invoke this command to find out who banned the use of words, such as "anime."